### PR TITLE
More granular classification of network errors in SocketsTransport to be sure that ConnectFailure response is returned only when corresponding request can be safely retried

### DIFF
--- a/Vostok.ClusterClient.Transport.Core20/Vostok.ClusterClient.Transport.Core20.csproj
+++ b/Vostok.ClusterClient.Transport.Core20/Vostok.ClusterClient.Transport.Core20.csproj
@@ -9,6 +9,7 @@
     <LangVersion>7.2</LangVersion>
     <RootNamespace>Vostok.Clusterclient.Transport.Core20</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Vostok.ClusterClient.Transport.Tests/Sockets/ErrorHandler_Tests.cs
+++ b/Vostok.ClusterClient.Transport.Tests/Sockets/ErrorHandler_Tests.cs
@@ -89,8 +89,6 @@ namespace Vostok.Clusterclient.Transport.Tests.Sockets
         [TestCase(SocketError.AddressNotAvailable)]
         [TestCase(SocketError.AddressAlreadyInUse)]
         [TestCase(SocketError.ConnectionRefused)]
-        [TestCase(SocketError.ConnectionAborted)]
-        [TestCase(SocketError.ConnectionReset)]
         [TestCase(SocketError.TimedOut)]
         [TestCase(SocketError.TryAgain)]
         [TestCase(SocketError.SystemNotReady)]
@@ -102,6 +100,17 @@ namespace Vostok.Clusterclient.Transport.Tests.Sockets
             Handle(new HttpRequestException("", new SocketException((int)code))).Code.Should().Be(ResponseCode.ConnectFailure);
 
             Handle(new HttpRequestException("", new IOException("", new SocketException((int)code)))).Code.Should().Be(ResponseCode.ConnectFailure);
+        }
+
+        [TestCase(SocketError.ConnectionAborted)]
+        [TestCase(SocketError.ConnectionReset)]
+        [TestCase(SocketError.Interrupted)]
+        [TestCase(SocketError.OperationAborted)]
+        public void Should_return_receive_failure_response_for_inner_SocketException_with_given_code(SocketError code)
+        {
+            Handle(new HttpRequestException("", new SocketException((int)code))).Code.Should().Be(ResponseCode.ReceiveFailure);
+
+            Handle(new HttpRequestException("", new IOException("", new SocketException((int)code)))).Code.Should().Be(ResponseCode.ReceiveFailure);
         }
 
         [Test]

--- a/Vostok.ClusterClient.Transport.Tests/Sockets/ErrorHandler_Tests.cs
+++ b/Vostok.ClusterClient.Transport.Tests/Sockets/ErrorHandler_Tests.cs
@@ -105,9 +105,9 @@ namespace Vostok.Clusterclient.Transport.Tests.Sockets
         }
 
         [Test]
-        public void Should_return_connection_failure_response_for_IOException_without_inner_exceptions()
+        public void Should_return_receive_failure_response_for_IOException_without_inner_exceptions()
         {
-            Handle(new HttpRequestException("", new IOException())).Code.Should().Be(ResponseCode.ConnectFailure);
+            Handle(new HttpRequestException("", new IOException())).Code.Should().Be(ResponseCode.ReceiveFailure);
         }
 
         [Test]

--- a/Vostok.ClusterClient.Transport.Tests/Vostok.ClusterClient.Transport.Tests.csproj
+++ b/Vostok.ClusterClient.Transport.Tests/Vostok.ClusterClient.Transport.Tests.csproj
@@ -8,6 +8,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <RootNamespace>Vostok.Clusterclient.Transport.Tests</RootNamespace>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Vostok.ClusterClient.Transport/Sockets/ErrorHandler.cs
+++ b/Vostok.ClusterClient.Transport/Sockets/ErrorHandler.cs
@@ -39,11 +39,11 @@ namespace Vostok.Clusterclient.Transport.Sockets
                     return Responses.SendFailure;
 
                 default:
-                    var connectionError = TryDetectConnectionError(error);
-                    if (connectionError != null)
+                    var (connectionErrorResponse, connectionError) = TryClassifyConnectionError(error);
+                    if (connectionErrorResponse != null)
                     {
                         LogConnectionFailure(request, connectionError, connectionTimeout);
-                        return Responses.ConnectFailure;
+                        return connectionErrorResponse;
                     }
 
                     break;
@@ -53,22 +53,22 @@ namespace Vostok.Clusterclient.Transport.Sockets
             return Responses.UnknownFailure;
         }
 
-        [CanBeNull]
-        private static Exception TryDetectConnectionError(Exception error)
+        private static (Response response, Exception connectionError) TryClassifyConnectionError(Exception error)
         {
             while (true)
             {
                 if (error == null)
-                    return null;
+                    return (response: null, connectionError: null);
 
                 if (error is OperationCanceledException)
-                    return error;
+                    return (Responses.ConnectFailure, connectionError: error);
 
                 if (error is SocketException socketError && IsConnectionFailure(socketError.SocketErrorCode))
-                    return error;
+                    return (Responses.ConnectFailure, connectionError: socketError);
 
+                // todo (avk, 24.12.2020): 'IOException with no InnerException' also happens on connection establishment and corresponding request can be safely retried
                 if (error is IOException ioError && ioError.InnerException == null)
-                    return error;
+                    return (Responses.ReceiveFailure, connectionError: ioError);
 
                 error = error.InnerException;
             }
@@ -105,9 +105,9 @@ namespace Vostok.Clusterclient.Transport.Sockets
             }
         }
 
-        private void LogConnectionFailure(Request request, Exception error, TimeSpan? connectionTimeout)
+        private void LogConnectionFailure(Request request, Exception connectionError, TimeSpan? connectionTimeout)
         {
-            if (error is OperationCanceledException)
+            if (connectionError is OperationCanceledException)
             {
                 log.Warn("Connection attempt timed out. Target = '{Target}'. Timeout = {ConnectionTimeout}.", new
                 {
@@ -118,7 +118,7 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 return;
             }
 
-            if (error is SocketException socketError)
+            if (connectionError is SocketException socketError)
             {
                 log.Warn("Connection failure. Target = '{Target}'. Socket code = {SocketErrorCode}. Timeout = {ConnectionTimeout}.", new
                 {
@@ -130,7 +130,7 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 return;
             }
 
-            log.Warn(error, "Connection failure. Target = '{Target}'.", request.Url.Authority);
+            log.Warn(connectionError, "Connection failure. Target = '{Target}'.", request.Url.Authority);
         }
 
         private void LogUserStreamFailure(Request request, Exception error)

--- a/Vostok.ClusterClient.Transport/Webrequest/ConnectTimeoutHelper.cs
+++ b/Vostok.ClusterClient.Transport/Webrequest/ConnectTimeoutHelper.cs
@@ -76,10 +76,8 @@ namespace Vostok.Clusterclient.Transport.Webrequest
                 WrapLog(log).Error(savedError, "Failed to build connection checker lambda");
         }
 
-        /// <summary>
-        /// Builds the following lambda:
-        /// (HttpWebRequest request) => request._SubmitWriteStream != null && request._SubmitWriteStream.InternalSocket != null && request._SubmitWriteStream.InternalSocket.Connected
-        /// </summary>
+        // Builds the following lambda:
+        // (HttpWebRequest request) => request._SubmitWriteStream != null && request._SubmitWriteStream.InternalSocket != null && request._SubmitWriteStream.InternalSocket.Connected
         private static Func<HttpWebRequest, bool> BuildSocketConnectedChecker()
         {
             var request = Expression.Parameter(typeof(HttpWebRequest));


### PR DESCRIPTION
IOException with no inner exception is also thrown by System.Net.Http.HttpConnection.FillAsync() when connection is prematurely closed by server:

https://github.com/dotnet/runtime/blob/db58dcdb2a3276a61ce7f12b5d20c40426362556/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L1568

```
2020-12-22 03:01:16,798 WARN  [T-84a2359b2f06448b931dde5e9481f05f] Connection failure. Target = 'example.com:14922'.
System.IO.IOException: The response ended prematurely.
   at System.Net.Http.HttpConnection.FillAsync()
   at System.Net.Http.HttpConnection.ReadNextResponseHeaderLineAsync(Boolean foldedHeadersAllowed)
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
```

Also more granular classification of socket errors is required to be sure that ConnectFailure response is returned only when corresponding request can be safely retried.