### PR TITLE
TcpKeepAlive for Net7

### DIFF
--- a/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
+++ b/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
@@ -40,7 +40,7 @@ namespace Vostok.Clusterclient.Transport.Core50
                         {
                             var host = context.DnsEndPoint.Host;
                             // https://github.com/dotnet/runtime/issues/24917
-                            var ips = await Dns.GetHostAddressesAsync(host);
+                            var ips = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
                             if (ips.Length == 0)
                             {
                                 throw new Exception($"{host} DNS lookup failed");

--- a/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
+++ b/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using JetBrains.Annotations;
 
@@ -11,10 +12,37 @@ namespace Vostok.Clusterclient.Transport.Core50
         private static readonly Encoding HeadersEncoding = new UTF8Encoding(false);
 
         [UsedImplicitly]
-        public static void Tune(HttpMessageHandler handler)
+        public static void Tune(HttpMessageHandler handler, bool tcpKeepAliveEnables, TimeSpan tcpKeepAliveInterval, TimeSpan tcpKeepAliveTime)
         {
             if (!(handler is SocketsHttpHandler socketHandler))
                 return;
+
+            if (tcpKeepAliveEnables)
+            {
+                var keepAliveTime = (int)tcpKeepAliveTime.TotalSeconds;
+                var keepAliveInterval = (int)tcpKeepAliveInterval.TotalSeconds;
+                
+                socketHandler.ConnectCallback = async (context, token) =>
+                {
+                    var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) {NoDelay = true};
+                    try
+                    {
+                        socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+                        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, keepAliveTime);
+                        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, keepAliveInterval);
+                        // (deniaa, 08.06.2023): We can configure an option (SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveRetryCount, X) here, but we have no this option in transport settings model.
+
+                        await socket.ConnectAsync(context.DnsEndPoint, token).ConfigureAwait(false);
+
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                };
+            }
 
             socketHandler.RequestHeaderEncodingSelector = (_, __) => HeadersEncoding;
             socketHandler.ResponseHeaderEncodingSelector = (_, __) => HeadersEncoding;

--- a/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
+++ b/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using JetBrains.Annotations;
@@ -76,7 +77,7 @@ namespace Vostok.Clusterclient.Transport.Core50
         {
             if (resolvedIps.Length == 1)
             {
-                return resolvedIps[0].AddressFamily is not (AddressFamily.InterNetworkV6 or AddressFamily.InterNetwork)
+                return NotValidIp(resolvedIps[0])
                     ? ArraySegment<IPAddress>.Empty
                     : new ArraySegment<IPAddress>(resolvedIps);
             }
@@ -85,7 +86,7 @@ namespace Vostok.Clusterclient.Transport.Core50
             var count = 0;
             foreach (var resolvedIp in resolvedIps)
             {
-                if (resolvedIp.AddressFamily is not (AddressFamily.InterNetworkV6 or AddressFamily.InterNetwork))
+                if (NotValidIp(resolvedIp))
                     continue;
 
                 addresses[count] = resolvedIp;
@@ -94,5 +95,9 @@ namespace Vostok.Clusterclient.Transport.Core50
 
             return new ArraySegment<IPAddress>(addresses, 0, count);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool NotValidIp(IPAddress ip) =>
+            ip.AddressFamily is not (AddressFamily.InterNetwork);
     }
 }

--- a/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
+++ b/Vostok.ClusterClient.Transport.Core50/SocketsHttpHandlerTuner.cs
@@ -77,8 +77,8 @@ namespace Vostok.Clusterclient.Transport.Core50
             if (resolvedIps.Length == 1)
             {
                 return resolvedIps[0].AddressFamily is not (AddressFamily.InterNetworkV6 or AddressFamily.InterNetwork)
-                    ? new ArraySegment<IPAddress>(resolvedIps)
-                    : ArraySegment<IPAddress>.Empty;
+                    ? ArraySegment<IPAddress>.Empty
+                    : new ArraySegment<IPAddress>(resolvedIps);
             }
 
             var addresses = new IPAddress[resolvedIps.Length];

--- a/Vostok.ClusterClient.Transport.Core50/Vostok.ClusterClient.Transport.Core50.csproj
+++ b/Vostok.ClusterClient.Transport.Core50/Vostok.ClusterClient.Transport.Core50.csproj
@@ -9,4 +9,8 @@
     <RootNamespace>Vostok.Clusterclient.Transport.Core50</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\vostok.commons.threading\Vostok.Commons.Threading\ThreadSafeRandom.cs" Link="Commons\ThreadSafeRandom.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Vostok.ClusterClient.Transport.Tests/Functional/Sockets/SocketsFunctionalTests.cs
+++ b/Vostok.ClusterClient.Transport.Tests/Functional/Sockets/SocketsFunctionalTests.cs
@@ -1,8 +1,51 @@
-﻿using NUnit.Framework;
+﻿using System.Threading;
+using FluentAssertions;
+using NUnit.Framework;
+using Vostok.Clusterclient.Core.Model;
 using Vostok.Clusterclient.Transport.Tests.Functional.Common;
+using Vostok.Clusterclient.Transport.Tests.Helpers;
+using Vostok.Commons.Environment;
+using Vostok.Commons.Time;
+using Vostok.Logging.Console;
 
 namespace Vostok.Clusterclient.Transport.Tests.Functional.Sockets
 {
+    internal class TcpKeepAliveOptionsTest
+    {
+        [SetUp]
+        public void CheckRuntime()
+        {
+            if (!RuntimeDetector.IsDotNetCore21AndNewer)
+                Assert.Pass();
+        }
+
+        /// <summary>
+        /// Starting with .net5, a specialized keepalive management API appeared for a SocketsHttpHandler.
+        /// And starting with .net7, the way we did before the appearance of .net5 broke
+        /// </summary>
+        [Test]
+        public void Should_send_large_request_body_with_keepalive_option()
+        {
+            const long size = 5L * 1024 * 1024;
+
+            using (var server = TestServer.StartNew(ctx => { ctx.Response.StatusCode = 200; }))
+            {
+                server.BufferRequestBody = false;
+
+                var transport = new SocketsTransport(new SocketsTransportSettings
+                {
+                    TcpKeepAliveEnabled = true, 
+                    TcpKeepAliveInterval = 5.Seconds(),
+                    TcpKeepAliveTime = 5.Seconds(),
+                }, new ConsoleLog());
+                var response = transport.SendAsync(Request.Post(server.Url).WithContent(new byte[size]), 750.Milliseconds(), 10.Minutes(), CancellationToken.None);
+
+                response.Result.Code.Should().Be(200);
+                server.LastRequest.BodySize.Should().Be(size);
+            }
+        }
+    }
+
     [Explicit]
     internal class AllowAutoRedirectTests : AllowAutoRedirectTests<SocketsTestsConfig>
     {

--- a/Vostok.ClusterClient.Transport.Tests/Vostok.ClusterClient.Transport.Tests.csproj
+++ b/Vostok.ClusterClient.Transport.Tests/Vostok.ClusterClient.Transport.Tests.csproj
@@ -4,8 +4,8 @@
   <Import Project="..\..\vostok.devtools\git-commit-to-assembly-title\Vostok.Tools.GitCommit2AssemblyTitle.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net471</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net471</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>Vostok.Clusterclient.Transport.Tests</RootNamespace>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/Vostok.ClusterClient.Transport/Helpers/NetCore50Utils.cs
+++ b/Vostok.ClusterClient.Transport/Helpers/NetCore50Utils.cs
@@ -12,7 +12,7 @@ namespace Vostok.Clusterclient.Transport.Helpers
         private const string Namespace = "Vostok.Clusterclient.Transport.Core50";
         private const string Library = "Vostok.ClusterClient.Transport.Core50.dll";
 
-        private static readonly Action<HttpMessageHandler> tuning;
+        private static readonly Action<HttpMessageHandler, bool, TimeSpan, TimeSpan> tuning;
 
         static NetCore50Utils()
         {
@@ -23,12 +23,22 @@ namespace Vostok.Clusterclient.Transport.Helpers
             var handlerTunerMethod = handlerTunerType.GetMethod("Tune", BindingFlags.Public | BindingFlags.Static);
 
             var handlerParameter = Expression.Parameter(typeof(HttpMessageHandler));
+            var tcpKeepAliveEnablesParameter = Expression.Parameter(typeof(bool));
+            var tcpKeepAliveIntervalParameter = Expression.Parameter(typeof(TimeSpan));
+            var tcpKeepAliveTimeParameter = Expression.Parameter(typeof(TimeSpan));
 
-            tuning = Expression.Lambda<Action<HttpMessageHandler>>(Expression.Call(handlerTunerMethod, handlerParameter), handlerParameter)
+            tuning = Expression.Lambda<Action<HttpMessageHandler, bool, TimeSpan, TimeSpan>>(
+                    Expression.Call(handlerTunerMethod, handlerParameter, tcpKeepAliveEnablesParameter, tcpKeepAliveIntervalParameter, tcpKeepAliveTimeParameter),
+                    handlerParameter,
+                    tcpKeepAliveEnablesParameter,
+                    tcpKeepAliveIntervalParameter,
+                    tcpKeepAliveTimeParameter)
                 .Compile();
         }
 
-        public static void TuneHandler(HttpMessageHandler handler)
-            => tuning(handler);
+        public static void TuneHandler(HttpMessageHandler handler, bool tcpKeepAliveEnables, TimeSpan tcpKeepAliveInterval, TimeSpan tcpKeepAliveTime)
+        {
+            tuning(handler, tcpKeepAliveEnables, tcpKeepAliveInterval, tcpKeepAliveTime);
+        }
     }
 }

--- a/Vostok.ClusterClient.Transport/Sockets/SocketAccessor.cs
+++ b/Vostok.ClusterClient.Transport/Sockets/SocketAccessor.cs
@@ -10,6 +10,11 @@ using Vostok.Logging.Abstractions;
 
 namespace Vostok.Clusterclient.Transport.Sockets
 {
+    /// <summary>
+    /// This class was created to set the TcpKeepalive options directly on the Socket in the HttpMessageHandler.
+    /// But due to significant changes in System.Net.Http.HttpConnection class it can't work starting from .Net7.
+    /// There is no _socket field. But starting from .Net5 HttpMessageHandler has a special api for setting TcpKeepAlive options.
+    /// </summary>
     internal static class SocketAccessor
     {
         private static readonly Func<Stream, Socket> Empty = _ => null;

--- a/Vostok.ClusterClient.Transport/Sockets/SocketsHandlerProvider.cs
+++ b/Vostok.ClusterClient.Transport/Sockets/SocketsHandlerProvider.cs
@@ -46,7 +46,10 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 settings.ClientCertificates,
                 settings.RemoteCertificateValidationCallback,
                 settings.Credentials,
-                settings.DecompressionMethods);
+                settings.DecompressionMethods,
+                settings.TcpKeepAliveEnabled,
+                settings.TcpKeepAliveInterval,
+                settings.TcpKeepAliveTime);
 
         private static HttpMessageHandler CreateHandler(GlobalCacheKey key)
         {
@@ -63,7 +66,7 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 key.DecompressionMethods);
 
             if (RuntimeDetector.IsDotNet50AndNewer)
-                NetCore50Utils.TuneHandler(handler);
+                NetCore50Utils.TuneHandler(handler, key.TcpKeepAliveEnables, key.TcpKeepAliveInterval, key.TcpKeepAliveTime);
 
             return handler;
         }
@@ -80,6 +83,9 @@ namespace Vostok.Clusterclient.Transport.Sockets
             public readonly RemoteCertificateValidationCallback RemoteCertificateValidationCallback;
             public readonly ICredentials Credentials;
             public readonly DecompressionMethods DecompressionMethods;
+            public readonly bool TcpKeepAliveEnables;
+            public readonly TimeSpan TcpKeepAliveInterval;
+            public readonly TimeSpan TcpKeepAliveTime;
 
             public GlobalCacheKey(
                 IWebProxy proxy,
@@ -91,7 +97,10 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 X509Certificate2[] clientCertificates,
                 RemoteCertificateValidationCallback remoteCertificateValidationCallback,
                 ICredentials credentials,
-                DecompressionMethods decompressionMethods)
+                DecompressionMethods decompressionMethods,
+                bool tcpKeepAliveEnables,
+                TimeSpan tcpKeepAliveInterval,
+                TimeSpan tcpKeepAliveTime)
             {
                 Proxy = proxy;
                 AllowAutoRedirect = allowAutoRedirect;
@@ -103,6 +112,9 @@ namespace Vostok.Clusterclient.Transport.Sockets
                 RemoteCertificateValidationCallback = remoteCertificateValidationCallback;
                 Credentials = credentials;
                 DecompressionMethods = decompressionMethods;
+                TcpKeepAliveEnables = tcpKeepAliveEnables;
+                TcpKeepAliveInterval = tcpKeepAliveInterval;
+                TcpKeepAliveTime = tcpKeepAliveTime;
             }
         }
 
@@ -122,7 +134,10 @@ namespace Vostok.Clusterclient.Transport.Sockets
                     x.MaxConnectionsPerEndpoint == y.MaxConnectionsPerEndpoint &&
                     x.RemoteCertificateValidationCallback == y.RemoteCertificateValidationCallback &&
                     Equals(x.Credentials, y.Credentials) &&
-                    x.DecompressionMethods == y.DecompressionMethods;
+                    x.DecompressionMethods == y.DecompressionMethods &&
+                    x.TcpKeepAliveEnables == y.TcpKeepAliveEnables &&
+                    x.TcpKeepAliveInterval == y.TcpKeepAliveInterval &&
+                    x.TcpKeepAliveTime == y.TcpKeepAliveTime;
             }
 
             public int GetHashCode(GlobalCacheKey key)
@@ -139,6 +154,9 @@ namespace Vostok.Clusterclient.Transport.Sockets
                     hashCode = (hashCode * 397) ^ (key.RemoteCertificateValidationCallback != null ? key.RemoteCertificateValidationCallback.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ (key.Credentials != null ? key.Credentials.GetHashCode() : 0);
                     hashCode = (hashCode * 397) ^ key.DecompressionMethods.GetHashCode();
+                    hashCode = (hashCode * 397) ^ key.TcpKeepAliveEnables.GetHashCode();
+                    hashCode = (hashCode * 397) ^ key.TcpKeepAliveInterval.GetHashCode();
+                    hashCode = (hashCode * 397) ^ key.TcpKeepAliveTime.GetHashCode();
                     return hashCode;
                 }
             }

--- a/Vostok.ClusterClient.Transport/SocketsTransport.cs
+++ b/Vostok.ClusterClient.Transport/SocketsTransport.cs
@@ -85,8 +85,12 @@ namespace Vostok.Clusterclient.Transport
                         state.Request.VersionPolicy = settings.HttpVersionPolicy.Value;
 #endif
 
+#if !NET5_0_OR_GREATER
+                    // Due to significant changes in System.Net.Http.HttpConnection class SocketTuningContent can't work starting from .Net7.
+                    // But starting from .Net5 HttpMessageHandler has a special api for setting TcpKeepAlive options. See in NetCore50Utils.TuneHandler and SocketsHttpHandlerTuner.
                     if (state.Request.Content is GenericContent content && socketTuner.CanTune)
                         state.Request.Content = new SocketTuningContent(content, socketTuner, log);
+#endif
 
                     var handler = handlerProvider.Obtain(connectionTimeout);
 


### PR DESCRIPTION
Due to significant changes in System.Net.Http.HttpConnection class SocketTuningContent can't work starting from .Net7. But starting from .Net5 HttpMessageHandler has a special api for setting TcpKeepAlive options. See in NetCore50Utils.TuneHandler and SocketsHttpHandlerTuner.